### PR TITLE
Fix: Correct loop behavior in random genre lyrics pipeline

### DIFF
--- a/pipelines/random_genre_lyrics_generation_pipeline.json
+++ b/pipelines/random_genre_lyrics_generation_pipeline.json
@@ -65,6 +65,11 @@
           "total_iterations_from": 4,
           "loop_body_start_id": "generate_random_genre",
           "counter_name": "generation_loop_counter",
+          "loop_body_agents": [
+            "generate_random_genre",
+            "generate_title_based_on_genre",
+            "generate_lyrics_based_on_genre_and_title"
+          ],
           "accumulators": {
             "all_genres": "genre",
             "all_titles": "title",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -287,8 +287,9 @@ def test_main_creation_path_confirmation_yes(
 @patch('main.json.load')
 @patch('main.sys.exit')
 @patch('builtins.print') # Mock print to suppress output during test if desired
+@patch('builtins.input', return_value='yes') # ADDED: Mock input for confirmation
 def test_main_run_specific_pipeline_test_mode(
-    mock_print, mock_sys_exit, mock_json_load, mock_fs_open, mock_orchestrator_class, mock_display_pipeline_flow
+    mock_input, mock_print, mock_sys_exit, mock_json_load, mock_fs_open, mock_orchestrator_class, mock_display_pipeline_flow
 ):
     config_path = 'tests/test_pipelines/random_genre_lyrics_generation_pipeline.json'
     # Simulate the content of the random_genre_lyrics_generation_pipeline.json
@@ -320,7 +321,7 @@ def test_main_run_specific_pipeline_test_mode(
 
     # Simulate command line arguments: main.py <config_path> --test-mode
     with patch('main.sys.argv', ['main.py', config_path, '--test-mode']):
-        main() # test_mode should be True when main is called
+        main(test_mode=True) # test_mode should be True when main is called
 
     # Assertions:
     # 1. display_pipeline_flow was called

--- a/tests/test_pipelines/random_genre_lyrics_generation_pipeline.json
+++ b/tests/test_pipelines/random_genre_lyrics_generation_pipeline.json
@@ -65,6 +65,11 @@
           "total_iterations_from": "num_iterations",
           "loop_body_start_id": "generate_random_genre",
           "counter_name": "generation_loop_counter",
+          "loop_body_agents": [
+            "generate_random_genre",
+            "generate_title_based_on_genre",
+            "generate_lyrics_based_on_genre_and_title"
+          ],
           "accumulators": {
             "all_genres": "genre",
             "all_titles": "title",


### PR DESCRIPTION
- Added `loop_body_agents` to the `ConditionalRouterTool` configuration in both the main and test versions of the `random_genre_lyrics_generation_pipeline.json`. This ensures that agent outputs are cleared between loop iterations, preventing stale data and enabling correct re-execution of loop body agents.
- Updated `test_main_run_specific_pipeline_test_mode` in `tests/test_main.py`:
  - Added mock for `builtins.input` to prevent `OSError` during test execution.
  - Ensured `main(test_mode=True)` is called to correctly propagate the `test_mode` flag, aligning the test setup with its assertion for Orchestrator initialization.